### PR TITLE
Specific versions on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Works great with https://github.com/chartjs/chartjs-plugin-datalabels or https:/
 ## Install
 
 ```bash
-npm install --save chart.js@next chartjs-chart-graph@next
+npm install --save chart.js@3.0.0-beta.9 chartjs-chart-graph@3.0.0-beta.9
 ```
 
 ## Usage


### PR DESCRIPTION
As commented in the open issue https://github.com/sgratzl/chartjs-chart-graph/issues/15, the versions of both libraries must match. This pull request corrects the readme so it specifies the right versions (3.0.0-beta.9).