### PR TITLE
add types for edge prefixed options

### DIFF
--- a/src/controllers/GraphController.ts
+++ b/src/controllers/GraphController.ts
@@ -1,7 +1,6 @@
 import {
   defaults,
   Chart,
-  Color,
   ScatterController,
   registry,
   LinearScale,
@@ -21,7 +20,7 @@ import {
   CoreChartOptions,
 } from 'chart.js';
 import { merge, clipArea, unclipArea, listenArrayEvents, unlistenArrayEvents } from 'chart.js/helpers';
-import { EdgeLine, IEdgeLineOptions } from '../elements';
+import { EdgeLine, IEdgeLineOptions, IEdgePrefixedOptions } from '../elements';
 import interpolatePoints from './interpolatePoints';
 import patchController from './patchController';
 
@@ -661,15 +660,9 @@ export interface IGraphEdgeDataPoint {
   target: number | string;
 }
 
-export interface EdgePrefixedOptions {
-  edgeLineBorderDash: number[];
-  edgeLineBorderWidth: number;
-  edgeLineBorderColor: Color;
-}
-
 export interface IGraphChartControllerDatasetOptions
   extends ControllerDatasetOptions,
-    ScriptableAndArrayOptions<EdgePrefixedOptions, ScriptableContext<'graph'>>,
+    ScriptableAndArrayOptions<IEdgePrefixedOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<PointPrefixedOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<PointPrefixedHoverOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<IEdgeLineOptions, ScriptableContext<'graph'>>,

--- a/src/controllers/GraphController.ts
+++ b/src/controllers/GraphController.ts
@@ -1,6 +1,7 @@
 import {
   defaults,
   Chart,
+  Color,
   ScatterController,
   registry,
   LinearScale,
@@ -660,8 +661,15 @@ export interface IGraphEdgeDataPoint {
   target: number | string;
 }
 
+export interface EdgePrefixedOptions {
+  edgeLineBorderDash: number[];
+  edgeLineBorderWidth: number;
+  edgeLineBorderColor: Color;
+}
+
 export interface IGraphChartControllerDatasetOptions
   extends ControllerDatasetOptions,
+    ScriptableAndArrayOptions<EdgePrefixedOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<PointPrefixedOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<PointPrefixedHoverOptions, ScriptableContext<'graph'>>,
     ScriptableAndArrayOptions<IEdgeLineOptions, ScriptableContext<'graph'>>,

--- a/src/elements/EdgeLine.ts
+++ b/src/elements/EdgeLine.ts
@@ -1,5 +1,6 @@
 import {
   ChartType,
+  Color,
   LineElement,
   LineOptions,
   PointElement,
@@ -43,6 +44,12 @@ export interface IEdgeLineOptions extends LineOptions {
   directed: boolean;
   arrowHeadSize: number;
   arrowHeadOffset: number;
+}
+
+export interface IEdgePrefixedOptions {
+  edgeLineBorderDash: number[];
+  edgeLineBorderWidth: number;
+  edgeLineBorderColor: Color;
 }
 
 export interface IEdgeLineProps extends LineOptions {


### PR DESCRIPTION
This pull request introduces TypeScript type declarations for the Edge Prefixed Options in the current plugin.

 Added the following properties to the `EdgePrefixedOptions` type:
   - `edgeLineBorderDash: number[];`
   - `edgeLineBorderWidth: number;`
   - `edgeLineBorderColor: Color;`
